### PR TITLE
Add missing format string in g_print

### DIFF
--- a/playerctl/playerctl-cli.c
+++ b/playerctl/playerctl-cli.c
@@ -87,7 +87,7 @@ int main (int argc, char *argv[])
   }
 
   if (command == NULL) {
-    g_print(g_option_context_get_help(context, TRUE, NULL));
+    g_print("%s", g_option_context_get_help(context, TRUE, NULL));
     return 0;
   }
 
@@ -158,7 +158,7 @@ int main (int argc, char *argv[])
     g_free(status);
   } else {
     /* unrecognized command */
-    g_print(g_option_context_get_help(context, TRUE, NULL));
+    g_print("%s", g_option_context_get_help(context, TRUE, NULL));
   }
 
   if (error != NULL) {


### PR DESCRIPTION
This fixes build failure due to compiler warning:

```
playerctl-cli.c: In function ‘main’:
playerctl-cli.c:90:5: warning: format not a string literal and no format arguments [-Wformat-security]
     g_print(g_option_context_get_help(context, TRUE, NULL));
     ^
playerctl-cli.c:161:5: warning: format not a string literal and no format arguments [-Wformat-security]
     g_print(g_option_context_get_help(context, TRUE, NULL));
     ^
```
