### PR TITLE
Add Guix installation instructions for playerctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,14 @@ sudo dnf install playerctl
 
 `playerctl` is available for Mageia and openSUSE via [this COPR repository](https://copr.fedorainfracloud.org/coprs/jflory7/playerctl/). First, install the repository file for your distribution from COPR. Then, install `playerctl` with your package manager of choice.
 
+### Guix
+
+`playerctl` is available as a [Guix](https://guix.gnu.org) package which can be installed on any Linux distribution after [installing Guix](https://guix.gnu.org/manual/en/html_node/Installation.html):
+
+```
+guix install playerctl
+```
+
 ### Compile from source
 
 Using the cli and library requires [GLib](https://developer.gnome.org/glib/) (which is a dependency of almost all of these players as well, so you probably already have it). You can use the library in almost any programming language with the associated [introspection binding library](https://wiki.gnome.org/Projects/GObjectIntrospection/Users).


### PR DESCRIPTION
Hi @acrisci!

I [recently contributed](http://git.savannah.gnu.org/cgit/guix.git/commit/gnu/packages/music.scm?id=1c463524c8325c434a437f358e71cd7191dce267) a package definition for playerctl into the [Guix](https://guix.gnu.org) package repository.  This is useful not only for those who have the Guix System distribution installed, but also for anyone who might install the standalone Guix package manager on their existing Linux distribution.

This PR adds some basic instructions on how one can install playerctl using the `guix` command.  If you think it isn't notable enough for inclusion as README section, I will understand; please feel free to close the PR in that case.

By the way, thanks for making playerctl!