### PR TITLE
implement a shift feature for playerctld

### DIFF
--- a/playerctl/playerctl-daemon.c
+++ b/playerctl/playerctl-daemon.c
@@ -811,7 +811,7 @@ static void player_signal_proxy_callback(GDBusConnection *connection, const gcha
         }
     }
 
-    if (is_properties_changed) {
+    if (is_properties_changed || player == context_get_active_player(ctx)) {
         g_dbus_connection_emit_signal(ctx->connection, NULL, object_path, interface_name,
                                       signal_name, parameters, &error);
         if (error != NULL) {

--- a/playerctl/playerctl-daemon.c
+++ b/playerctl/playerctl-daemon.c
@@ -332,9 +332,32 @@ static void context_remove_player(struct PlayerctldContext *ctx, struct Player *
     }
 }
 
+static void context_shift_active_player(struct PlayerctldContext *ctx) {
+    GError *error = NULL;
+    struct Player *p;
+
+    p = context_get_active_player(ctx);
+    context_remove_player(ctx, p);
+    context_add_player(ctx, p);
+    context_emit_active_player_changed(ctx, &error);
+
+    p = context_get_active_player(ctx);
+    player_update_position_sync(p, ctx, &error);
+    if (error != NULL) {
+        g_warning("could not emit active player change: %s", error->message);
+        g_clear_error(&error);
+    }
+    if (error != NULL) {
+        g_warning("could not update player position: %s", error->message);
+        g_clear_error(&error);
+    }
+}
+
 static const char *playerctld_introspection_xml =
     "<node>\n"
     "  <interface name=\"com.github.altdesktop.playerctld\">\n"
+    "    <method name=\"Shift\">\n"
+    "    </method>\n"
     "    <property name=\"PlayerNames\" type=\"as\" access=\"read\"/>\n"
     "    <signal name=\"ActivePlayerChangeBegin\">\n"
     "        <arg name=\"Name\" type=\"s\"/>\n"
@@ -484,6 +507,31 @@ static void player_method_call_proxy_callback(GDBusConnection *connection, const
     g_object_unref(message);
 }
 
+static void playerctld_method_call_func(GDBusConnection *connection, const char *sender,
+                                              const char *object_path, const char *interface_name,
+                                              const char *method_name, GVariant *parameters,
+                                              GDBusMethodInvocation *invocation,
+                                              gpointer user_data) {
+    g_debug("got method call: sender=%s, object_path=%s, interface_name=%s, method_name=%s", sender,
+            object_path, interface_name, method_name);
+    struct PlayerctldContext *ctx = user_data;
+    struct Player *active_player = context_get_active_player(ctx);
+    if (active_player == NULL) {
+        g_debug("no active player, returning error");
+        g_dbus_method_invocation_return_dbus_error(
+            invocation, "com.github.altdesktop.playerctld.NoActivePlayer",
+            "No player is being controlled by playerctld");
+        return;
+    }
+
+    if (strcmp(method_name, "Shift")) {
+        g_dbus_method_invocation_return_dbus_error(
+            invocation, "com.github.altdesktop.playerctld.InvalidMethod",
+            "This method is not valid");
+    }
+    context_shift_active_player(ctx);
+}
+
 static GVariant *playerctld_get_property_func(GDBusConnection *connection, const gchar *sender,
                                               const gchar *object_path, const gchar *interface_name,
                                               const gchar *property_name, GError **error,
@@ -502,7 +550,7 @@ static GDBusInterfaceVTable vtable_player = {player_method_call_proxy_callback, 
 
 static GDBusInterfaceVTable vtable_root = {player_method_call_proxy_callback, NULL, NULL, {0}};
 
-static GDBusInterfaceVTable vtable_playerctld = {NULL, playerctld_get_property_func, NULL, {0}};
+static GDBusInterfaceVTable vtable_playerctld = {playerctld_method_call_func, playerctld_get_property_func, NULL, {0}};
 
 static void on_bus_acquired(GDBusConnection *connection, const char *name, gpointer user_data) {
     GError *error = NULL;
@@ -737,6 +785,12 @@ static void player_signal_proxy_callback(GDBusConnection *connection, const gcha
     }
 
     if (player != context_get_active_player(ctx)) {
+        GVariantDict dict;
+        g_variant_dict_init(&dict, player->player_properties);
+        GVariant *prop_variant = g_variant_dict_lookup_value(&dict, "PlaybackStatus", G_VARIANT_TYPE_STRING);
+        const gchar *status = g_variant_get_string(prop_variant, NULL);
+        if (!!g_strcmp0(status, "Playing"))
+            return;
         g_debug("new active player: %s", player->well_known);
         context_set_active_player(ctx, player);
         player_update_position_sync(player, ctx, &error);

--- a/playerctl/playerctl-daemon.c
+++ b/playerctl/playerctl-daemon.c
@@ -516,10 +516,9 @@ static void player_method_call_proxy_callback(GDBusConnection *connection, const
 }
 
 static void playerctld_method_call_func(GDBusConnection *connection, const char *sender,
-                                              const char *object_path, const char *interface_name,
-                                              const char *method_name, GVariant *parameters,
-                                              GDBusMethodInvocation *invocation,
-                                              gpointer user_data) {
+                                        const char *object_path, const char *interface_name,
+                                        const char *method_name, GVariant *parameters,
+                                        GDBusMethodInvocation *invocation, gpointer user_data) {
     g_debug("got method call: sender=%s, object_path=%s, interface_name=%s, method_name=%s", sender,
             object_path, interface_name, method_name);
     struct PlayerctldContext *ctx = user_data;
@@ -536,9 +535,9 @@ static void playerctld_method_call_func(GDBusConnection *connection, const char 
         context_shift_active_player(ctx);
         g_dbus_method_invocation_return_value(invocation, NULL);
     } else {
-        g_dbus_method_invocation_return_dbus_error(
-            invocation, "com.github.altdesktop.playerctld.InvalidMethod",
-            "This method is not valid");
+        g_dbus_method_invocation_return_dbus_error(invocation,
+                                                   "com.github.altdesktop.playerctld.InvalidMethod",
+                                                   "This method is not valid");
     }
 }
 
@@ -560,7 +559,8 @@ static GDBusInterfaceVTable vtable_player = {player_method_call_proxy_callback, 
 
 static GDBusInterfaceVTable vtable_root = {player_method_call_proxy_callback, NULL, NULL, {0}};
 
-static GDBusInterfaceVTable vtable_playerctld = {playerctld_method_call_func, playerctld_get_property_func, NULL, {0}};
+static GDBusInterfaceVTable vtable_playerctld = {
+    playerctld_method_call_func, playerctld_get_property_func, NULL, {0}};
 
 static void on_bus_acquired(GDBusConnection *connection, const char *name, gpointer user_data) {
     GError *error = NULL;
@@ -812,8 +812,8 @@ static void player_signal_proxy_callback(GDBusConnection *connection, const gcha
     }
 
     if (is_properties_changed) {
-        g_dbus_connection_emit_signal(ctx->connection, NULL, object_path, interface_name, signal_name,
-                                      parameters, &error);
+        g_dbus_connection_emit_signal(ctx->connection, NULL, object_path, interface_name,
+                                      signal_name, parameters, &error);
         if (error != NULL) {
             g_debug("could not emit signal: %s", error->message);
             g_clear_error(&error);
@@ -839,10 +839,9 @@ int main(int argc, char *argv[]) {
     g_debug("connected to dbus: %s", g_dbus_connection_get_unique_name(ctx.connection));
 
     if (argc == 2) {
-        g_dbus_connection_call_sync(
-            ctx.connection, "org.mpris.MediaPlayer2.playerctld",
-            MPRIS_PATH, PLAYERCTLD_INTERFACE, "Shift", NULL, NULL,
-            G_DBUS_CALL_FLAGS_NO_AUTO_START, -1, NULL, &error);
+        g_dbus_connection_call_sync(ctx.connection, "org.mpris.MediaPlayer2.playerctld", MPRIS_PATH,
+                                    PLAYERCTLD_INTERFACE, "Shift", NULL, NULL,
+                                    G_DBUS_CALL_FLAGS_NO_AUTO_START, -1, NULL, &error);
         g_object_unref(ctx.connection);
         if (error != NULL) {
             g_printerr("%s", error->message);

--- a/playerctl/playerctl-daemon.c
+++ b/playerctl/playerctl-daemon.c
@@ -86,7 +86,7 @@ static bool player_update_properties(struct Player *player, const char *interfac
     GVariant *child;
     const gchar *prop_status, *cache_status;
     bool is_player_interface = false;  // otherwise, the root interface
-    bool is_properties_updated = false; // have the properties actually updated
+    bool is_properties_updated = true; // have the properties actually updated
 
     if (g_strcmp0(interface_name, PLAYER_INTERFACE) == 0) {
         g_variant_dict_init(&cached_properties, player->player_properties);
@@ -115,7 +115,7 @@ static bool player_update_properties(struct Player *player, const char *interfac
             goto loop_out;
         }
         GVariant *cache_value = g_variant_dict_lookup_value(&cached_properties, key, NULL);
-        if (cache_value != NULL && is_player_interface) {
+        if (cache_value != NULL && is_player_interface && is_properties_updated) {
             if (g_strcmp0(key, "PlaybackStatus") == 0) {
                 cache_status = g_variant_get_string(cache_value, NULL);
                 prop_status = g_variant_get_string(prop_value, NULL);

--- a/playerctl/playerctl-daemon.c
+++ b/playerctl/playerctl-daemon.c
@@ -862,7 +862,7 @@ int playercmd_shift(GDBusConnection *connection) {
                                 G_DBUS_CALL_FLAGS_NO_AUTO_START, -1, NULL, &error);
     g_object_unref(connection);
     if (error != NULL) {
-        g_printerr("%s", error->message);
+        g_printerr("Cannot shift: %s\n", error->message);
         return 1;
     }
     return 0;


### PR DESCRIPTION
This implements the feature suggested in #170

The daemon exposes a dbus method called ```Shift```, that the user can interact with to request a shift. At the moment that dbus method needs to be interacted with manually using a tool like dbus-send.

The following command requests a shift:
> dbus-send --type=method_call --dest=org.mpris.MediaPlayer2.playerctld /org/mpris/MediaPlayer2 com.github.altdesktop.playerctld.Shift

This dbus command can be incorporated in playerctl, so that the user can do something like ```playerctl shift``` which will execute the above dbus method call. I tried my best to implement the dbus method, but I could not figure out how to send a proper response, so I have to use ```type=method_call``` instead of ```--print-reply```.

Additionally, I have added some logic to first check the status of the 'new' player before setting it active. This is necessary because some players (i.e. spotify) will send dbus updates periodically, even when paused, which will automatically set it as the most recent player. The only downside is that explicitly pausing the player does not make it most recent, but the more intuitive notion of 'most recent' is the most recent player to be Playing.
