### PR TITLE
Improve zsh completion parsing

### DIFF
--- a/data/playerctl.zsh
+++ b/data/playerctl.zsh
@@ -11,7 +11,7 @@ __playerctl_ctx() {
 		${(kv)opt_args[(I)-i|--ignore-player]}
 		${(kv)opt_args[(I)-a|--all-players]}
 	)
-	__playerctl "$opt_args[@]" "$@"
+	__playerctl "$player_opts[@]" "$@"
 }
 
 local -a playercmd_loop=(/$'(none|track|playlist)\0'/ ':(none track playlist)')
@@ -26,8 +26,11 @@ _playerctl_players() {
 
 (( $+functions[_playerctl_metadata_keys] )) ||
 _playerctl_metadata_keys() {
-	local -a metadata=( ${(@f)"$(__playerctl_ctx metadata)"} )
-	local -a keys=( ${${metadata#* }%% *} )
+	local -a keys
+	__playerctl_ctx metadata |
+	while read PLAYER KEY VALUE; do
+		keys+="$KEY"
+	done
 	_multi_parts "$@" -i ":" keys
 }
 local -a playerctl_command_metadata_keys=(/$'[^\0]#\0'/ ':keys:key:_playerctl_metadata_keys')


### PR DESCRIPTION
I noticed that my previous method for parsing keys from metadata output isn't quite sufficient. It actually fails on short player names that have more space padding.

So I changed the metadata parsing to be more robust, and I also corrected a typo so that __playerctl_ctx actually uses the declared player_opts array. The purpose of these is to give the user context specific suggestions for metadata keys based on the player/ignore opts they gave earlier in the command.