### PR TITLE
docs: fix simple typo, propery -> property

### DIFF
--- a/playerctl/playerctl-cli.c
+++ b/playerctl/playerctl-cli.c
@@ -228,7 +228,7 @@ static gboolean playercmd_stop(PlayerctlPlayer *player, gchar **argv, gint argc,
     GError *tmp_error = NULL;
     gchar *instance = pctl_player_get_instance(player);
 
-    // XXX there is no CanStop propery on the mpris player. CanPlay is supposed
+    // XXX there is no CanStop property on the mpris player. CanPlay is supposed
     // to indicate whether there is a current track. If there is no current
     // track, then I assume the player cannot stop.
     gboolean can_play = FALSE;


### PR DESCRIPTION
There is a small typo in playerctl/playerctl-cli.c.

Should read `property` rather than `propery`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md