### PR TITLE
Add `trunc` helper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ playerctl metadata --format "Volume: {{ volume * 100 }}"
 | `markup_escape` | string           | Escape XML markup characters in the string.                        |
 | `default`       | any, any         | Print the first value if it is present, or else print the second.  |
 | `emoji`         | status or volume | Try to convert the variable to an emoji representation.            |
+| `trunc`         | string, int      | Truncate string to a maximum length.                               |
 
 | Variable     | Description                                       |
 | ------------ | ------------------------------------------------- |

--- a/doc/playerctl.1.in
+++ b/doc/playerctl.1.in
@@ -251,6 +251,12 @@ to an emoji representation. Currently implemented for
 .Fa status
 and
 .Fa volume .
+.It Fn trunc str len
+Truncate
+.Fa str
+to a maximum of
+.Fa len
+characters, adding an ellipsis (…) if necessary.
 .El
 .Pp
 The template language is also able to perform basic math operations.

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -114,6 +114,10 @@ async def test_format(bus_address):
     test.add(' {{lc(album)}} ', album.lower())
     test.add('{{playerName}} - {{playerInstance}}',
              f'{player_name} - {player_instance}')
+    test.add("{{trunc(title, 10)}}", title)
+    test.add("{{trunc(title, 5)}}", f"{title[:5]}…")
+    test.add('{{trunc("", 0)}}', "")
+    test.add('{{trunc("", 10)}}', "")
 
     await test.run()
 


### PR DESCRIPTION
hello, this adds a `trunc()` helper function to truncate long text
eg. on my statusbar where there is limited space I could shorted long track names
eg

```shell
$ playerctl metadata -f '{{lc(status)}} "{{title}}"'
playing "Doctor Blowfin's Water Cruiser"
$ playerctl metadata -f '{{lc(status)}} "{{trunc(title, 25)}}"'
playing "Doctor Blowfin's Water Cr…"
```

if you'll accept this PR I can update it for docs/readme/etc

thanks!