### PR TITLE
Fix typo in zsh completions (palyer -> player)

### DIFF
--- a/data/playerctl.zsh
+++ b/data/playerctl.zsh
@@ -43,7 +43,7 @@ _regex_words commands 'playerctl command' \
 	'stop:Command the player to stop' \
 	'next:Command the player to skip to the next track' \
 	'previous:Command the player to skip to the previous track' \
-	'position:Command the palyer to go or seek to the position' \
+	'position:Command the player to go or seek to the position' \
 	'volume:Print or set the volume level from 0.0 to 1.0' \
 	'status:Get the play status of the player' \
 	'metadata:Print the metadata information for the current track:$playerctl_command_metadata_keys' \


### PR DESCRIPTION
Hi there! Thanks for all the work that you do on playerctl. I just saw a little typo while using it in the zsh completions so I fixed that up and here it is! That's all, a pretty simple contribution. It's not much, but it's honest work :)