### PR TITLE
Fail when listing players and none were selected

### DIFF
--- a/playerctl/playerctl-cli.c
+++ b/playerctl/playerctl-cli.c
@@ -935,12 +935,15 @@ static int handle_list_all_flag() {
         }
     }
 
-    if (!one_selected && !no_status_error_messages) {
-        g_printerr("No players found\n");
+    if (!one_selected) {
+        if (!no_status_error_messages) {
+            g_printerr("No players found\n");
+        }
+        exit_status = 1;
     }
 
     pctl_player_name_list_destroy(player_names_list);
-    return 0;
+    return exit_status;
 }
 
 static void managed_players_execute_command(GError **error) {

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -17,7 +17,7 @@ async def test_basics():
 
     # with no players
     result = await playerctl.run('--list-all')
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 1, result.stderr
     assert not result.stdout
     assert result.stderr
 


### PR DESCRIPTION
Otherwise scripts using playerctl have to grep the output instead.
