### PR TITLE
Fix incorrect use of g_error

### DIFF
--- a/playerctl/playerctl-player.c
+++ b/playerctl/playerctl-player.c
@@ -418,7 +418,7 @@ static void playerctl_player_get_property(GObject *object, guint property_id, GV
         GVariant *metadata = NULL;
         metadata = playerctl_player_get_metadata(self, &error);
         if (error != NULL) {
-            g_error("could not get metadata: %s", error->message);
+            g_printerr("could not get metadata: %s", error->message);
             g_clear_error(&error);
         }
         g_value_set_variant(value, metadata);


### PR DESCRIPTION
`g_error()` is only intended for programming errors that you cannot recover from. The way it is used here crashes the application when metadata could not be retrieved because of external factors.

Reference:
- https://developer-old.gnome.org/glib/unstable/glib-Error-Reporting.html#glib-Error-Reporting.description
- https://developer-old.gnome.org/glib/unstable/glib-Message-Logging.html#g-error