### PR TITLE
fix: Checks if message body is NULL before getting number of children.

### DIFF
--- a/playerctl/playerctl-daemon.c
+++ b/playerctl/playerctl-daemon.c
@@ -738,7 +738,7 @@ static void proxy_method_call_async_callback(GObject *source_object, GAsyncResul
         g_dbus_method_invocation_return_value(invocation, body);
         break;
     case G_DBUS_MESSAGE_TYPE_ERROR: {
-        if (g_variant_n_children(body) > 1) {
+        if (body != NULL && g_variant_n_children(body) > 1) {
             GVariant *error_message_variant = g_variant_get_child_value(body, 1);
             const char *error_message = g_variant_get_string(error_message_variant, 0);
             g_dbus_method_invocation_return_dbus_error(


### PR DESCRIPTION
Fixes segmentation fault from calling `g_variant_n_children` on  NULL GVariant*. The body returned by `g_dbus_message_get_body` can be NULL (https://docs.gtk.org/gio/method.DBusMessage.get_body.html) which is not accounted for in current error handling code.

```
Thread 1 "playerctld" received signal SIGSEGV, Segmentation fault.
g_bit_lock (address=0x30, lock_bit=0) at ../glib/glib/gbitlock.c:219
219	 __asm__ volatile goto ("lock bts %1, (%0)\n"
(gdb) bt
#0  g_bit_lock (address=0x30, lock_bit=0) at ../glib/glib/gbitlock.c:219
#1  0x00007ffff7e96c93 in g_variant_lock (value=0x0) at ../glib/glib/gvariant-core.c:263
#2  g_variant_n_children (value=0x0) at ../glib/glib/gvariant-core.c:1102
#3  0x000055555555984f in proxy_method_call_async_callback
    (source_object=0x555555568d80 [GDBusConnection], res=0x555555588340, user_data=0x7fffec00dad0)
    at ../playerctl/playerctl-daemon.c:741
#4  0x00007ffff7cc64cc in g_task_return_now (task=0x555555588340 [GTask]) at ../glib/gio/gtask.c:1361
#5  0x00007ffff7cc6515 in complete_in_idle_cb (task=0x555555588340) at ../glib/gio/gtask.c:1375
#6  0x00007ffff7e49559 in g_main_dispatch (context=0x5555555770b0) at ../glib/glib/gmain.c:3357
#7  0x00007ffff7eac257 in g_main_context_dispatch_unlocked (context=0x5555555770b0)
    at ../glib/glib/gmain.c:4208
#8  g_main_context_iterate_unlocked.isra.0
    (context=0x5555555770b0, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>)
    at ../glib/glib/gmain.c:4273
#9  0x00007ffff7e4a287 in g_main_loop_run (loop=0x55555557e950) at ../glib/glib/gmain.c:4475
#10 0x000055555555c2cc in main (argc=1, argv=0x7fffffffe1d8) at ../playerctl/playerctl-daemon.c:1525
```

Probably Fixes:
- #339
- #268 